### PR TITLE
Fix for setup instruction script failing when _config.yml has an empty setup_docs

### DIFF
--- a/bin/get_setup.py
+++ b/bin/get_setup.py
@@ -63,7 +63,3 @@ with open("setup.md", "w") as file_out:
             doc_filepath = 'submodules/setup-documents/markdown/' + setup
             with open(doc_filepath, "r", encoding="utf-8") as file_in:
                 file_out.write('\n\n' + file_in.read())
-
-
-
-


### PR DESCRIPTION
This fixes an issue that would arise when setup_docs in a _config.yml would be missing or an empty list. 

Also addresses some formatting issues, namely adding lesson titles and stopping certain headings being indented following a bullet list.