### PR TITLE
Copy all lesson data and improve build scripts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,6 @@ setup_docs:
 lessons:
   - title: Best Practices in Data Organisation Using Spreadsheets
     gh-name: spreadsheets
-    type: episode
     branch: main
     date: 13 January 2022
     start-time: 15:00
@@ -61,7 +60,6 @@ lessons:
 
   - title: Data Cleaning with OpenRefine
     gh-name: openrefine-data-cleaning
-    type: episode
     branch: main
     date: 14 January 2022
     start-time: 15:00
@@ -69,7 +67,6 @@ lessons:
 
   - title: Managing Academic Software Development
     gh-name: project-novice
-    type: episode
     branch: main
     date: 10 January 2022
     start-time: 9:30 am
@@ -78,7 +75,6 @@ lessons:
   - title: Automating Tasks with the Unix Shell  # Lesson title
     org-name: Southampton-RSG-Training           # Name of the GitHub organisation (or individual) the lesson is in defaults to Southampton-RSG-Training
     gh-name: shell-novice                        # Name of the GitHub repository for the lesson at https://github:com/{org-name}:
-    type: episode                                # Currently only 'episode' is valid
     branch: main                                 # Set the branch of the repository to use, useful for lesson customization
     date: 8 January 2022                         # The date of the lesson                   # date and start-time are required for z
     start-time: 10:30 am                         # The start time of the lesson             # 'kind: workshop'
@@ -86,7 +82,6 @@ lessons:
 
   - title: Version Control with git
     gh-name: git-novice
-    type: episode
     branch: main
     date: 9 January 2022
     start-time: 8:30 am
@@ -94,7 +89,6 @@ lessons:
 
   - title: Building Programs with Python
     gh-name: python-novice
-    type: episode
     branch: main
     date:
       - 11 January 2022

--- a/bin/build_me.sh
+++ b/bin/build_me.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-echo 'Getting sub modules'
+set -e -x
+
 python3 bin/get_submodules.py
-echo 'Making favicons'
 python3 bin/make_favicons.py
-echo 'Making schedules'
 python3 bin/get_schedules.py
-echo 'Making setup'
 python3 bin/get_setup.py

--- a/bin/get_schedules.py
+++ b/bin/get_schedules.py
@@ -9,16 +9,14 @@ and creates a detailed 00-schedule.md file for each lesson.
 """
 
 import datetime
-import yaml
 import math
-import pandas
 import glob
 import textwrap
-from bs4 import BeautifulSoup as bs
 from pathlib import Path
 import string
-from enum import Enum
-import dateutil
+from bs4 import BeautifulSoup as bs
+import yaml
+from dateutil.parser import parse
 
 
 def get_yaml_config():
@@ -62,7 +60,7 @@ def get_date_object(date_string):
     if date_string.lower() == "tbc":
         return date_string.upper()
     else:
-        return dateutil.parser.parse(date_string).date()
+        return parse(date_string).date()
 
 def get_time_object(time_string):
     """Convert a string into a datetime object.
@@ -234,8 +232,11 @@ def main():
     a detailed syllabus.
     """
     website_config = get_yaml_config()
-    website_kind = website_config.get('kind')
-    website_delivery = website_config.get('delivery')
+    website_kind = website_config.get('kind', None)
+    website_delivery = website_config.get('delivery', None)  # None is fine for lessons, but will raise exception for workshops
+
+    if website_kind is None:
+        raise KeyError("website_kind type has not been specified in _config.yml")
 
     # create generic schedule layout for lessons
 
@@ -243,7 +244,6 @@ def main():
     schedule_sessions = [
         "Registration, questions, and technical help", "Teaching", "Break", "Teaching", "Wrap Up", "Finish"
     ]
-
 
     # Try to parse the start and end date for the workshop, to check that lessons
     # are in the correct time frame. If the date is not a valid date, i.e. if it
@@ -255,10 +255,10 @@ def main():
     # Iterate over each lesson, to add their schedule to the html_schedules string
 
     lessons = website_config.get("lessons", None)
+    if not lessons:
+        raise ValueError("No lessons found in the workshop configuration file (_config.yml)")
     if website_kind == 'lesson':
         lessons = [website_config]  # This is a hack
-    elif not lessons:
-        raise ValueError("No lessons found in the workshop configuration file (_config.yml)")
     lesson_schedules = []
 
     for lesson in lessons:
@@ -269,6 +269,16 @@ def main():
         lesson_start_times = lesson.get("start-time", None)      # can be a list
         lesson_order = lesson.get("order", None)
 
+        # check that the inputs are correct to avoid ambiguous errors later
+        if website_kind not in ['workshop', 'lesson']:
+            raise ValueError(f'website_kind of "{website_kind}" is an unknown kind. Known: workshop, lesson')
+        if website_kind == 'workshop' and website_delivery not in ['dated', 'static']:
+            raise ValueError(
+                f'website_delivery of "{website_delivery}" is an unknown delivery option for workshops. Known: dated, static'
+            )
+
+        # the next two blocks are used to check that all the required options
+        # are provided in the configuration yaml
         if website_kind == 'workshop':
             if website_delivery == 'dated':
                 assrt_opts = (lesson_name, lesson_dates, lesson_title, lesson_start_times)
@@ -285,7 +295,6 @@ def main():
                     raise ValueError(f"gh-name, title, and order are required for a static workshop")
             if website_kind == 'lesson':
                 raise ValueError(f"title and start-time are required for lesson")
-
 
         # Since we allow multiple dates and start times per lesson, we need to be
         # able to iterate over even single values so turn into list. When done,
@@ -367,7 +376,7 @@ def main():
                 start_time = get_time_object(lesson_start_times[0])
                 start_time_minutes = start_time.hour * 60 + start_time.minute
                 create_detailed_lesson_schedules(lesson_name, lesson_type, start_time_minutes, lesson_title, website_kind)
-            elif website_delivery == 'static':
+            else:
                 path = Path(f"_includes/rsg/{lesson_name}-lesson/blurb.html")
 
                 if path.is_file():
@@ -386,11 +395,11 @@ def main():
                 lesson_schedules.append({"order_on": lesson_order, "schedule": table})
 
                 create_detailed_lesson_schedules(lesson_name, lesson_type, 0, lesson_title,website_kind)
-                # make some untimed schedules
-        elif website_kind == 'lesson':
+        else:
             start_time = get_time_object(lesson_start_times)
             start_time_minutes = start_time.hour * 60 + start_time.minute
             create_detailed_lesson_schedules('', lesson_type, start_time_minutes, lesson_title, website_kind)
+
     if website_kind != 'lesson':
         create_index_schedules(lesson_schedules)
 

--- a/bin/get_schedules.py
+++ b/bin/get_schedules.py
@@ -371,7 +371,7 @@ def main():
                     </div>
                     """
 
-                    lesson_schedules.append({"order_on": lesson_dates[i], "schedule": table})
+                    lesson_schedules.append({"order_on": date, "schedule": table})
 
                 start_time = get_time_object(lesson_start_times[0])
                 start_time_minutes = start_time.hour * 60 + start_time.minute

--- a/bin/get_submodules.py
+++ b/bin/get_submodules.py
@@ -134,7 +134,7 @@ for n, lesson_info in enumerate(website_config['lessons']):
     # Move lesson episodes into the _episodes directory
     lesson_content_dest = f"_episodes/{lesson_name}-lesson"
     Path(lesson_content_dest).mkdir(parents=True, exist_ok=True)
-    copytree(f"submodules/{lesson_name}/_episodes/", lesson_content_dest)
+    copytree(f"submodules/{lesson_name}/_episodes/", lesson_content_dest, dirs_exist_ok=True)
 
     # move any extra lesson files into the same directory as the episodes, e.g.
     # the glossary is a good example
@@ -159,19 +159,19 @@ for n, lesson_info in enumerate(website_config['lessons']):
 
     # Moves figures into fig directory
     try:
-        copytree(f"submodules/{lesson_name}/fig", "fig/")
+        copytree(f"submodules/{lesson_name}/fig", "fig/", dirs_exist_ok=True)
     except IOError:
         log.info(f"No figures to move for {lesson_name}")
 
     # Move lesson data into data directory
     try:
-        copytree(f"submodules/{lesson_name}/data", "data/")
+        copytree(f"submodules/{lesson_name}/data", "data/", dirs_exist_ok=True)
     except IOError:
         log.info(f"No data file to move for {lesson_name}")
 
     # Move codes for lessons into code directory
     try:
-        copytree(f"submodules/{lesson_name}/code", "code/")
+        copytree(f"submodules/{lesson_name}/code", "code/", dirs_exist_ok=True)
     except IOError:
         log.info(f"No code files for {lesson_name}")
 
@@ -190,13 +190,13 @@ for n, lesson_info in enumerate(website_config['lessons']):
     if slides_src.is_dir():
         slides_dest = Path(f"slides/{lesson_name}/")
         slides_dest.mkdir(parents=True, exist_ok=True)
-        copytree(f"submodules/{lesson_name}/slides", str(slides_dest))
+        copytree(f"submodules/{lesson_name}/slides", str(slides_dest), dirs_exist_ok=True)
 
         # The lesson reveal.js folder which gets copied is empty, so delete that
         # and copy the reveal.js submodule
         rmtree(f"slides/{lesson_name}/reveal.js", ignore_errors=True)
         Path(f"slides/{lesson_name}/reveal.js").mkdir(parents=True, exist_ok=True)
-        copytree("submodules/reveal.js", f"slides/{lesson_name}/reveal.js")
+        copytree("submodules/reveal.js", f"slides/{lesson_name}/reveal.js", dirs_exist_ok=True)
 
         # slides are built using pandoc in this script -- sometimes we seem to
         # need to specify revealjs-url

--- a/bin/get_submodules.py
+++ b/bin/get_submodules.py
@@ -3,133 +3,204 @@ from each lesson into the appropriate directory structure.
 """
 
 import os
-from enum import Enum
 import logging
+from shutil import copy2 as copy
+from shutil import rmtree
+from shutil import copytree
+from pathlib import Path
+from typing import Tuple
+
 from yaml import load
+
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
-from pathlib import Path
-from distutils.dir_util import copy_tree
 import requests
-from shutil import copy2 as copy, rmtree
+from requests.exceptions import ConnectTimeout
 
 log = logging.getLogger(__name__)
 
-# Remove previously existing directories, to start fresh
 
-rmtree("submodules", ignore_errors=True)
-rmtree("collections", ignore_errors=True)
-rmtree("slides", ignore_errors=True)
+def check_org_name_and_branch(lesson_name: str, org_name: str, gh_branch: str) -> Tuple[str, str]:
+    """
+    Check the GH org name and branch are correct for a lesson.
 
-# Open the website config, which contains a list of the lessons we want in the
-# workshop, then create the directory "submodules" which will contain the files
-# for each lesson
+    This checks to see if the provided org_name and gh_branch all
+    work with the lesson provided by lesson_name. If either org_name or
+    gh_branch are correct, e.g. the GitHub API returns an error or times out,
+    then default values are tried for gh_page or org_name
 
-with open('_config.yml') as config:
-    website_config = load(config, Loader=Loader)
-log.info(f"Getting submodules specified in {website_config['lessons']}")
-Path("submodules").mkdir(parents=True, exist_ok=True)
+    Parameters
+    ----------
+    lesson_name:
+        The name of the lesson to check
+    org_name:
+        The proposed org name where the lesson repo should exist.
+    gh_branch:
+        The proposed branch of the repo containing the lesson.
+    """
+    ret_org_name = org_name
+    ret_gh_branch = gh_branch
 
-# Now process each lesson in the list
+    try:
+        r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}', timeout=7)
+    except ConnectTimeout as exc:
+        raise Exception(f"Connection timeout when trying to find {org_name}/{lesson_name} repository") from exc
 
-for n, lesson_info in enumerate(website_config['lessons']):
-    directory = "./_episodes"
-    # Create the command to pull the subdirectory from GitHub
-    org_name = lesson_info.get("org-name", "Southampton-RSG-Training")
-    lesson_name = lesson_info.get('gh-name', None)
-    if lesson_name is None:
-        raise ValueError(f"No lesson name specified for lesson {n}")
-    gh_branch = lesson_info.get('branch', 'main')
-    # Check this repository exists
-    r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}')
     if r.status_code != 200:
         log.warning(f'Lesson {lesson_name} does not exist in {org_name} trying in default org')
-        r = requests.get(f'https://api.github.com/repos/Southampton-RSG-Training/{lesson_name}')
+
+        try:
+            r = requests.get(f'https://api.github.com/repos/Southampton-RSG-Training/{lesson_name}', timeout=7)
+        except ConnectTimeout as exc:
+            raise Exception(f"Connection timeout when trying to find Southampton-RSG-Training/{lesson_name} repository") from exc
+
         if r.status_code == 200:
             log.warning(f"Lesson {lesson_name} found in 'Southampton-RSG-Training' using as fallback")
             org_name = "Southampton-RSG-Training"
         else:
             raise ValueError(f"Lesson {lesson_name} does not exist in '{org_name}', or 'Southampton-RSG-Training'")
     else:
-        r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}/branches/{gh_branch}')
+        try:
+            r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}/branches/{gh_branch}', timeout=7)
+        except ConnectTimeout as exc:
+            raise Exception("Connection timeout when trying to find {gh_branch} branch in {org_name}/{lesson_name}") from exc
+
         if r.status_code != 200:
             log.warning(f'Branch {gh_branch} does not exist in {org_name}/{lesson_name} trying default branch')
-            r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}/branches/gh-pages')
+
+            try:
+                r = requests.get(f'https://api.github.com/repos/{org_name}/{lesson_name}/branches/gh-pages', timeout=7)
+            except ConnectTimeout as exc:
+                raise Exception("Connection timeout when trying to find gh-pages branch in {org_name}/{lesson}") from exc
+
             if r.status_code == 200:
                 log.warning(f'Branch {gh_branch} found in {org_name}/{lesson_name} using as fallback')
                 gh_branch = "gh-pages"
             else:
                 raise ValueError(f"Branch '{gh_branch}' or 'gh-pages' does not exist in '{org_name}/{lesson_name}', or 'Southampton-RSG-Training'")
 
+    return ret_org_name, ret_gh_branch
+
+
+# Remove previously existing directories, to start fresh
+
+rmtree("submodules", ignore_errors=True)
+# rmtree("slides", ignore_errors=True)
+
+Path("submodules").mkdir(parents=True, exist_ok=True)
+
+# Open the website config, which contains a list of the lessons we want in the
+# workshop, then create the directory "submodules" which will contain the files
+# for each lesson
+
+with open('_config.yml', 'r') as config:
+    website_config = load(config, Loader=Loader)
+
+log.info(f"Getting submodules specified in {website_config['lessons']}")
+
+# Now process each lesson in the list
+
+for n, lesson_info in enumerate(website_config['lessons']):
+
+    # Create the command to pull the sub-directory from GitHub
+    org_name = lesson_info.get("org-name", "Southampton-RSG-Training")
+    lesson_name = lesson_info.get('gh-name', None)
+    if not lesson_name:
+        raise ValueError(f"No lesson name specified for lesson {n}")
+    gh_branch = lesson_info.get('branch', 'main')
+
+    org_name, gh_branch = check_org_name_and_branch(lesson_name, org_name, gh_branch)
     log.info(f"Getting lesson with parameters:\n org-name: {org_name} \n gh-name: {lesson_name} \n branch: {gh_branch}")
+
     os.system(f"git submodule add --force -b {gh_branch} https://github.com/{org_name}/{lesson_name}.git submodules/{lesson_name}")
     os.system("git submodule update --remote --merge")
 
     # move required files from the subdirectories to _includes/rsg/{lesson_name}/...
     # lesson destinations need to be appended with -lesson to avoid gh-pages naming conflicts
 
-    # Things to move to ./_includes/rsg -- for lesson schedules and setup
-    dest = f"_includes/rsg/{lesson_name}-lesson"
-    Path(dest).mkdir(parents=True, exist_ok=True)
+    # Things to move to ./_includes/rsg
+    includes_dest = f"_includes/rsg/{lesson_name}-lesson"
+    Path(includes_dest).mkdir(parents=True, exist_ok=True)
+
     for file in ["blurb.html"]:
         try:
-            copy(f"submodules/{lesson_name}/{file}", f"{dest}/{file.split('/')[-1]}")
-            log.info(f"Copied submodules/{lesson_name}/{file} to {dest}")
-        except:
+            copy(f"submodules/{lesson_name}/{file}", f"{includes_dest}/{file.split('/')[-1]}")
+            log.info(f"Copied submodules/{lesson_name}/{file} to {includes_dest}")
+        except IOError:
             log.error(f"Cannot find or move submodules/{lesson_name}/{file}, but carrying on anyway")
 
-    # Things to move to ./collections/... -- episodes and extras
-    dest = f"{directory}/{lesson_name}-lesson"
-    Path(dest).mkdir(parents=True, exist_ok=True)
-    copy_tree(f"submodules/{lesson_name}/{directory}/", dest)
+    # Move lesson episodes into the _episodes directory
+    lesson_content_dest = f"_episodes/{lesson_name}-lesson"
+    Path(lesson_content_dest).mkdir(parents=True, exist_ok=True)
+    copytree(f"submodules/{lesson_name}/_episodes/", lesson_content_dest)
+
+    # move any extra lesson files into the same directory as the episodes, e.g.
+    # the glossary is a good example
     for file in ["reference.md"]:
         try:
-            dest = f"{directory}/{lesson_name}-lesson"
-            Path(dest).mkdir(parents=True, exist_ok=True)
-            copy(f"submodules/{lesson_name}/{file}", f"{dest}/{file.split('/')[-1]}")
-            log.info(f"Copied submodules/{lesson_name}/{file} to {dest}")
-        except:
+            copy(f"submodules/{lesson_name}/{file}", f"{lesson_content_dest}/{file.split('/')[-1]}")
+        except IOError:
             log.error(f"Cannot find or move submodules/{lesson_name}/{file}, but carrying on anyway")
 
-    for file in os.listdir(dest):
+    # now we need to add two additional frontmatter variables to link the
+    # lesson episodes to the correct syllabus/schedule
+    for file in os.listdir(lesson_content_dest):
         if file.endswith(".md"):
-            with open(f"{dest}/{file}", "r") as f:
+            with open(f"{lesson_content_dest}/{file}", "r") as f:
                 contents = f.readlines()
+            contents.insert(
+                1,
+                f"lesson_title: '{lesson_info.get('title', '')}'\nlesson_schedule_slug: {lesson_name}-schedule\n"
+            )
+            with open(f"{lesson_content_dest}/{file}", "w") as f:
+                f.write("".join(contents))
 
-            contents.insert(1, f"lesson_title: '{lesson_info.get('title', '')}'\n"
-                                f"lesson_schedule_slug: {lesson_name}-schedule\n")
-
-            with open(f"{dest}/{file}", "w") as f:
-                contents = "".join(contents)
-                f.write(contents)
-
-    # Move figures
-    copy_tree(f"submodules/{lesson_name}/fig", "fig/")
-    # Move data
+    # Moves figures into fig directory
     try:
-        copy_tree(f"submodules/{lesson_name}/data", "data/")
-    except:
-        log.info(f"No data file to move in {lesson_name}")
+        copytree(f"submodules/{lesson_name}/fig", "fig/")
+    except IOError:
+        log.info(f"No figures to move for {lesson_name}")
 
-# Now need to do the same for slides, but have to do it afterwards because we
-# need a specific version of reveal.js, so we need to avoid the git submodule
+    # Move lesson data into data directory
+    try:
+        copytree(f"submodules/{lesson_name}/data", "data/")
+    except IOError:
+        log.info(f"No data file to move for {lesson_name}")
+
+    # Move codes for lessons into code directory
+    try:
+        copytree(f"submodules/{lesson_name}/code", "code/")
+    except IOError:
+        log.info(f"No code files for {lesson_name}")
+
+# Now need to do copy the slides over, but have to do it afterwards because we
+# need a specific version of reveal.js and so we need to avoid the git submodule
 # update
 
 os.system("git submodule add --force https://github.com/hakimel/reveal.js.git submodules/reveal.js")
 os.system("cd submodules/reveal.js && git checkout 8a54118f43")
 
 for n, lesson_info in enumerate(website_config['lessons']):
+    # if we've gotten here, am gonna assume lesson_name exists
     lesson_name = lesson_info.get('gh-name', None)
-    if lesson_name is None:
-        raise ValueError("No lesson name specified for lesson {n}")
+    slides_src = Path(f"submodules/{lesson_name}/slides")
+    # not all lessons have slides, so check the dir exists
+    if slides_src.is_dir():
+        slides_dest = Path(f"slides/{lesson_name}/")
+        slides_dest.mkdir(parents=True, exist_ok=True)
+        copytree(f"submodules/{lesson_name}/slides", str(slides_dest))
 
-    if Path(f"submodules/{lesson_name}/slides").is_dir():
-        Path(f"slides/{lesson_name}-lesson").mkdir(parents=True, exist_ok=True)
-        copy_tree(f"submodules/{lesson_name}/slides", f"slides/{lesson_name}-lesson")
         # The lesson reveal.js folder which gets copied is empty, so delete that
-        # directory and then copy in the reveal.js submodule downloaded earlier
-        rmtree(f"slides/{lesson_name}-lesson/reveal.js", ignore_errors=True)
-        Path(f"slides/{lesson_name}-lesson/reveal.js").mkdir(parents=True, exist_ok=True)
-        copy_tree("submodules/reveal.js", f"slides/{lesson_name}-lesson/")
+        # and copy the reveal.js submodule
+        rmtree(f"slides/{lesson_name}/reveal.js", ignore_errors=True)
+        Path(f"slides/{lesson_name}/reveal.js").mkdir(parents=True, exist_ok=True)
+        copytree("submodules/reveal.js", f"slides/{lesson_name}/reveal.js")
+
+        # slides are built using pandoc in this script -- sometimes we seem to
+        # need to specify revealjs-url
+        pandoc_command = "pandoc -t revealjs -s -o index.html index.md -V theme=black --slide-level=3 "
+        pandoc_command += "revealjs-url='https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.9.2'"
+
+        os.system(f"cd slides/{lesson_name} && {pandoc_command}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-PyYAML
-beautifulsoup4
-git_root
-pandas
-html5lib
-python-dateutil
-lxml
-favicons
+PyYAML==5.3.1
+beautifulsoup4==4.11.2
+python-dateutil==2.8.2
+favicons==0.1.1
+requests==2.22.0


### PR DESCRIPTION
This PR addresses issues #17, #18 and #19.

- The index schedules for dated workshop will be ordered by date, instead of "alphabetically"
- Slides are now built by the GitHub action for workshops and can be access via, e.g., site.com/slides/git-novice/ or site.com/slides/project-novice
- There is more input checking which should make it easier to tell when you've used a wrong parameter
- Figures, code and data are now copied from each lesson into the workshop directories